### PR TITLE
Update files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 This is the repository for the Checkmk Agent plugin.
 
+[![CodeFactor](https://www.codefactor.io/repository/github/donimax/unraid-check-mk-agent/badge/master)](https://www.codefactor.io/repository/github/donimax/unraid-check-mk-agent/overview/master)
+
 ## Install the Checkmk Agent plugin on Unraid using these URLs.
+
+check_mk agent v2.3.0pXX:
+<https://raw.githubusercontent.com/donimax/unraid-check-mk-agent/master/check_mk_agent23.plg>
 
 check_mk agent v2.2.0pXX:
 <https://raw.githubusercontent.com/donimax/unraid-check-mk-agent/master/check_mk_agent22.plg>
@@ -25,7 +30,7 @@ docker run -it --rm -v $(pwd)/:/build vbatts/slackware:15.0 sh /build/source/com
 ## Checkmk docker and smart plugin
 
 Requirements:
-- NerdTools plugin with python3
+- `Python 3 for UNRAID` plugin
 - User Scripts plugin
 - Checkmk server
 
@@ -70,7 +75,7 @@ done
 
 #Install Checkmk Docker and smart plugin
 rm -rf ${PLUGIN_DIR}
-mkdir ${PLUGIN_DIR}
+mkdir -p ${PLUGIN_DIR}
 cd ${PLUGIN_DIR}
 wget ${CHECK_MK_SERVER_URL}check_mk/agents/plugins/mk_docker.py
 chmod 755  mk_docker.py

--- a/check_mk_agent.plg
+++ b/check_mk_agent.plg
@@ -59,8 +59,8 @@ rm -f $(ls &plugin;/packages/*.txz 2>/dev/null|grep -v '&xinetd;')
 
 Monitors local services and reports any issues to the Checkmk server.  
 The agents are passive and connect to TCP Port 6556. Only on receiving a Checkmk server query will they be activated and respond with the required data.  
-To install plugins place them in '/boot/config/plugins/check_mk_agent/plugins'  
-To use encryption edit the file '/boot/config/plugins/check_mk_agent/encryption.cfg'
+To install plugins, place them in '/usr/lib/check_mk_agent/plugins', but they will need to be downloaded again after each reboot.  
+To use encryption, edit the file '/boot/config/plugins/check_mk_agent/encryption.cfg'.  
 </INLINE>
 </FILE>
 
@@ -70,14 +70,6 @@ To use encryption edit the file '/boot/config/plugins/check_mk_agent/encryption.
 #Download icon
 if [ ! -f "&plugin;/checkmk.png" ]; then
   wget -q -nc --show-progress --progress=bar:force:noscroll -O "&plugin;/&name;.png" "https://raw.githubusercontent.com/donimax/unraid-docker-templates/master/donimax/images/checkmk.png"
-fi
-
-#Create plugins directory and link directories
-if [ ! -d "&plugin;/plugins" ]; then
-  mkdir -p &plugin;/plugins
-  ln -s /boot/config/plugins/check_mk_agent/plugins /usr/lib/check_mk_agent/plugins
-else
-  ln -s /boot/config/plugins/check_mk_agent/plugins /usr/lib/check_mk_agent/plugins
 fi
 
 #Create encryption file and link file

--- a/check_mk_agent20.plg
+++ b/check_mk_agent20.plg
@@ -59,8 +59,8 @@ rm -f $(ls &plugin;/packages/*.txz 2>/dev/null|grep -v '&xinetd;')
 
 Monitors local services and reports any issues to the Checkmk server.  
 The agents are passive and connect to TCP Port 6556. Only on receiving a Checkmk server query will they be activated and respond with the required data.  
-To install plugins place them in '/usr/lib/check_mk_agent/plugins'  
-To use encryption edit the file '/boot/config/plugins/check_mk_agent/encryption.cfg'
+To install plugins, place them in '/usr/lib/check_mk_agent/plugins', but they will need to be downloaded again after each reboot.  
+To use encryption, edit the file '/boot/config/plugins/check_mk_agent/encryption.cfg'.  
 </INLINE>
 </FILE>
 
@@ -70,14 +70,6 @@ To use encryption edit the file '/boot/config/plugins/check_mk_agent/encryption.
 #Download icon
 if [ ! -f "&plugin;/checkmk.png" ]; then
   wget -q -nc --show-progress --progress=bar:force:noscroll -O "&plugin;/&name;.png" "https://raw.githubusercontent.com/donimax/unraid-docker-templates/master/donimax/images/checkmk.png"
-fi
-
-#Create plugins directory and link directories
-if [ ! -d "&plugin;/plugins" ]; then
-  mkdir -p &plugin;/plugins
-  ln -s /boot/config/plugins/check_mk_agent/plugins /usr/lib/check_mk_agent/plugins
-else
-  ln -s /boot/config/plugins/check_mk_agent/plugins /usr/lib/check_mk_agent/plugins
 fi
 
 #Create encryption file and link file

--- a/check_mk_agent21.plg
+++ b/check_mk_agent21.plg
@@ -113,8 +113,8 @@ rm -f $(ls &plugin;/packages/*.txz 2>/dev/null|grep -v '&xinetd;')
 
 Monitors local services and reports any issues to the Checkmk server.  
 The agents are passive and connect to TCP Port 6556. Only on receiving a Checkmk server query will they be activated and respond with the required data.  
-To install plugins place them in '/usr/lib/check_mk_agent/plugins'  
-To use encryption edit the file '/boot/config/plugins/check_mk_agent/encryption.cfg'
+To install plugins, place them in '/usr/lib/check_mk_agent/plugins', but they will need to be downloaded again after each reboot.  
+To use encryption, edit the file '/boot/config/plugins/check_mk_agent/encryption.cfg'.  
 </INLINE>
 </FILE>
 
@@ -129,14 +129,6 @@ fi
 #Download icon
 if [ ! -f "&plugin;/checkmk.png" ]; then
   wget -q -nc --show-progress --progress=bar:force:noscroll -O "&plugin;/&name;.png" "https://raw.githubusercontent.com/donimax/unraid-docker-templates/master/donimax/images/checkmk.png"
-fi
-
-#Create plugins directory and link directories
-if [ ! -d "&plugin;/plugins" ]; then
-  mkdir -p &plugin;/plugins
-  ln -s /boot/config/plugins/check_mk_agent/plugins /usr/lib/check_mk_agent/plugins
-else
-  ln -s /boot/config/plugins/check_mk_agent/plugins /usr/lib/check_mk_agent/plugins
 fi
 
 #Create encryption file and link file

--- a/check_mk_agent22.plg
+++ b/check_mk_agent22.plg
@@ -129,8 +129,8 @@ rm -f $(ls &plugin;/packages/*.txz 2>/dev/null|grep -v '&xinetd;')
 
 Monitors local services and reports any issues to the Checkmk server.  
 The agents are passive and connect to TCP Port 6556. Only on receiving a Checkmk server query will they be activated and respond with the required data.  
-To install plugins place them in '/usr/lib/check_mk_agent/plugins'  
-To use encryption edit the file '/boot/config/plugins/check_mk_agent/encryption.cfg'
+To install plugins, place them in '/usr/lib/check_mk_agent/plugins', but they will need to be downloaded again after each reboot.  
+To use encryption, edit the file '/boot/config/plugins/check_mk_agent/encryption.cfg'.  
 </INLINE>
 </FILE>
 
@@ -145,14 +145,6 @@ fi
 #Download icon
 if [ ! -f "&plugin;/checkmk.png" ]; then
   wget -q -nc --show-progress --progress=bar:force:noscroll -O "&plugin;/&name;.png" "https://raw.githubusercontent.com/donimax/unraid-docker-templates/master/donimax/images/checkmk.png"
-fi
-
-#Create plugins directory and link directories
-if [ ! -d "&plugin;/plugins" ]; then
-  mkdir -p &plugin;/plugins
-  ln -s /boot/config/plugins/check_mk_agent/plugins /usr/lib/check_mk_agent/plugins
-else
-  ln -s /boot/config/plugins/check_mk_agent/plugins /usr/lib/check_mk_agent/plugins
 fi
 
 #Create encryption file and link file

--- a/check_mk_agent23.plg
+++ b/check_mk_agent23.plg
@@ -93,8 +93,8 @@ rm -f $(ls &plugin;/packages/*.txz 2>/dev/null|grep -v '&xinetd;')
 
 Monitors local services and reports any issues to the Checkmk server.  
 The agents are passive and connect to TCP Port 6556. Only on receiving a Checkmk server query will they be activated and respond with the required data.  
-To install plugins place them in '/usr/lib/check_mk_agent/plugins'  
-To use encryption edit the file '/boot/config/plugins/check_mk_agent/encryption.cfg'
+To install plugins, place them in '/usr/lib/check_mk_agent/plugins', but they will need to be downloaded again after each reboot.  
+To use encryption, edit the file '/boot/config/plugins/check_mk_agent/encryption.cfg'.  
 </INLINE>
 </FILE>
 
@@ -109,14 +109,6 @@ fi
 #Download icon
 if [ ! -f "&plugin;/checkmk.png" ]; then
   wget -q -nc --show-progress --progress=bar:force:noscroll -O "&plugin;/&name;.png" "https://raw.githubusercontent.com/donimax/unraid-docker-templates/master/donimax/images/checkmk.png"
-fi
-
-#Create plugins directory and link directories
-if [ ! -d "&plugin;/plugins" ]; then
-  mkdir -p &plugin;/plugins
-  ln -s /boot/config/plugins/check_mk_agent/plugins /usr/lib/check_mk_agent/plugins
-else
-  ln -s /boot/config/plugins/check_mk_agent/plugins /usr/lib/check_mk_agent/plugins
 fi
 
 #Create encryption file and link file

--- a/source/compile_docker.sh
+++ b/source/compile_docker.sh
@@ -34,4 +34,4 @@ md5sum check_mk_agent-"$(date +'%Y.%m.%d')".$VERSION.tgz > check_mk_agent-"$(dat
 
 # Move to packages folder and cleanup
 mv check_mk_agent-"$(date +'%Y.%m.%d')".$VERSION.tgz check_mk_agent-"$(date +'%Y.%m.%d')".$VERSION.tgz.md5 /build/packages
-rm -rf ${DATA_DIR}/*
+rm -rf ${DATA_DIR:?}/*


### PR DESCRIPTION
- Removed symlink creation as FAT32 does not support extend Linux permissions
- Updated plugin description regarding check_mk additional plugin installation
- added codefactor badge
- Changed Docker plugin requirements due to NerdTools deprecation and easier Python management via community plugin
- Fixed shellcheck [SC2115](https://github.com/koalaman/shellcheck/wiki/SC2115) in compile_docker file